### PR TITLE
Case 34243: Education - extending Snapshot Block to use links and downloads

### DIFF
--- a/web/themes/custom/hm-public-theme/static/sass/content/_content.scss
+++ b/web/themes/custom/hm-public-theme/static/sass/content/_content.scss
@@ -1,6 +1,7 @@
 // Generic content styles
 .wrapper .body {
   @extend %max-width;
+  margin-bottom: em(50);
   width: 70%;
 
   p {

--- a/web/themes/custom/hm-public-theme/static/sass/shared/_snapshot-blocks.scss
+++ b/web/themes/custom/hm-public-theme/static/sass/shared/_snapshot-blocks.scss
@@ -40,6 +40,14 @@
     width: 50%;
   }
 
+  .snapshot--download svg {
+    height: em(15);
+  }
+
+  .snapshot--link svg {
+    width: em(12);
+  }
+
 }
 
 // Two column snapshot container

--- a/web/themes/custom/hm-public-theme/templates/paragraph/paragraph--snapshot-block.html.twig
+++ b/web/themes/custom/hm-public-theme/templates/paragraph/paragraph--snapshot-block.html.twig
@@ -6,7 +6,11 @@
  * Available variables using Paragraphs:
  * -  field_snapshot_header
  * -  field_snapshot_content
+ *
+ * Snapshot CTA:
  * -  field_snapshot_button
+ * -  field_snapshot_download
+ * -  field_snapshot_link 
  *
  */
 #}
@@ -14,20 +18,20 @@
 {# <ol>
   <li>Snapshot Header:  {{ content.field_snapshot_header }}</li>
   <li>Snapshot Content: {{ content.field_snapshot_content }}</li>
-  <li>Snapshot Button URL:  {{ content.field_snapshot_button|field_raw('uri') }}</li>
-  <li>Snapshot Button Title:  {{ content.field_snapshot_button|field_raw('title') }}</li>
 </ol> #}
 
 <div class="snapshot">
+
   {% if content.field_snapshot_image|field_value is not empty %}
     <div class="snapshot--image" style="background-image: url('{{ file_url(content.field_snapshot_image|field_target_entity.uri.value) }}');" alt="{{ content.field_snapshot_image|field_raw('alt') }}"></div>
   {% endif %}
+
   <h3 style="color: {{ content.field_snapshot_header_color|field_value }}">{{ content.field_snapshot_header|field_value }}</h3>
   <h4>{{ content.field_snapshot_subtitle|field_value }}</h4>
   <p>{{ content.field_snapshot_content|field_value }}</p>
-  {% if content.field_snapshot_button|field_value is not empty %}
-    <a href="{{ content.field_snapshot_button|field_raw('uri') }}" class="button button--primary">
-      {{ content.field_snapshot_button|field_raw('title') }}
-    </a>
+
+  {% if content.field_snapshot_cta|field_value is not empty %}
+    {{ content.field_snapshot_cta|field_value }}
   {% endif %} 
+  
 </div>

--- a/web/themes/custom/hm-public-theme/templates/paragraph/paragraph--snapshot-button.html.twig
+++ b/web/themes/custom/hm-public-theme/templates/paragraph/paragraph--snapshot-button.html.twig
@@ -1,0 +1,14 @@
+{#
+/**
+ * @file
+ * Theme override for Snapshot Block element.
+ *
+ */
+#}
+
+{# URL:  {{ content.field_snapshot_button|field_raw('uri') }}
+Title:  {{ content.field_snapshot_button|field_raw('title') }} #}
+
+<a href="{{ content.field_snapshot_button|field_raw('uri') }}" class="button button--primary">
+  {{ content.field_snapshot_button|field_raw('title') }}
+</a>

--- a/web/themes/custom/hm-public-theme/templates/paragraph/paragraph--snapshot-download.html.twig
+++ b/web/themes/custom/hm-public-theme/templates/paragraph/paragraph--snapshot-download.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override for Snapshot Block element.
+ *
+ */
+#}
+
+{# File Name:  {{ content.field_snapshot_file_name|field_value }}
+URL:  {{ content.field_snapshot_file_download|field_value }} #}
+
+<div class="snapshot--download">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 44.44 57.3"><title>Download</title><g id="30c2dd7b-ede7-496f-b8b5-2670f62da8bd" data-name="Layer 2"><g id="2956cd67-78d7-4503-bd40-df077cc04845" data-name="Layer 1"><path d="M18.59,3.63v32L6.19,23.71a3.74,3.74,0,0,0-5.13,0,3.41,3.41,0,0,0,0,4.94l18.6,17.9a3.7,3.7,0,0,0,5.12,0l18.6-17.9a3.41,3.41,0,0,0,0-4.94,3.72,3.72,0,0,0-5.12,0L25.85,35.66v-32a3.63,3.63,0,0,0-7.26,0Z" style="fill:#999"/><path d="M40.81,50H3.63a3.63,3.63,0,0,0,0,7.26H40.81a3.63,3.63,0,0,0,0-7.26Z" style="fill:#999"/></g></g></svg>
+  <a href="{{ content.field_snapshot_file_download|field_value }}" download="{{ content.field_snapshot_file_name|field_value }}">
+    {{ content.field_snapshot_file_name|field_value }}
+  </a>
+</div>

--- a/web/themes/custom/hm-public-theme/templates/paragraph/paragraph--snapshot-link.html.twig
+++ b/web/themes/custom/hm-public-theme/templates/paragraph/paragraph--snapshot-link.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override for Snapshot Block element.
+ *
+ */
+#}
+
+{# URL:  {{ content.field_snapshot_link_url|field_raw('uri') }}
+Text:  {{ content.field_snapshot_link_url|field_raw('title') }} #}
+
+<div class="snapshot--link">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 47.58 44.44"><title>Link</title><g id="456be250-5941-4060-bff6-c633de575b5a" data-name="Layer 2"><g id="5fded011-40df-476d-b681-997c58c3df29" data-name="Layer 1"><path d="M3.63,25.85h32L23.71,38.26a3.72,3.72,0,0,0,0,5.12,3.4,3.4,0,0,0,4.94,0l17.9-18.59a3.71,3.71,0,0,0,0-5.13L28.65,1.06a3.41,3.41,0,0,0-4.94,0,3.74,3.74,0,0,0,0,5.13l11.95,12.4h-32a3.63,3.63,0,0,0,0,7.26Z" style="fill:#999"/></g></g></svg>
+  <a href="{{ content.field_snapshot_link_url|field_raw('uri') }}">
+    {{ content.field_snapshot_link_url|field_raw('title') }}
+  </a>
+</div> 


### PR DESCRIPTION
grouped buttons, download, and links into a CTA option available to the user to add multiple of.